### PR TITLE
Add flag to allow use without first setting WiFi credentials

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #define XY_TX_PIN 5
 
 //#define USE_BUTTON_CTRL
+//#define ALLOW_PERMANENT_ADMIN_MODE
 
 #include <ESP_MultiResetDetector.h>
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -16,11 +16,15 @@ void WebServer::init(bool admin_mode) {
   Serial.println(WiFi.localIP());
 
   mWebServer.on("/style.css", std::bind(&WebServer::handleStyleCss, this));
+#ifndef ALLOW_PERMANENT_ADMIN_MODE
   if (admin_mode) {
     mWebServer.on("/", std::bind(&WebServer::handleSettings, this));
   } else {
+#endif
     mWebServer.on("/", std::bind(&WebServer::handleRoot, this));
+#ifndef ALLOW_PERMANENT_ADMIN_MODE
   }
+#endif
   mWebServer.on("/settings.html", std::bind(&WebServer::handleSettings, this));
   mWebServer.on("/logic.js", std::bind(&WebServer::handleLogicJs, this));
   mWebServer.on("/segment-display.js",


### PR DESCRIPTION
Can I say that this project is completely fantastic, and exactly the thing I was looking for, since the encoder for some reason stopped working on my XY6020 power supply, which I really needed for something. This turned out to be an easy way to work around that, and an upgrade at the same time. So thank you!

This allows the device to be used permanently in soft AP mode, and releases it from being dependent on any host network. Useful if you just want to connect to the device directly.